### PR TITLE
Handle ListFields with ForeignKeys referencing strings instead of actual classes.

### DIFF
--- a/djangotoolbox/fields.py
+++ b/djangotoolbox/fields.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.db.models.fields.subclassing import Creator
 from django.db.utils import IntegrityError
 from django.utils.importlib import import_module
-
+from django.db.models.fields.related import add_lazy_relation
 
 __all__ = ('RawField', 'ListField', 'SetField', 'DictField',
            'EmbeddedModelField', 'BlobField')
@@ -83,6 +83,16 @@ class AbstractIterableField(models.Field):
         item_metaclass = getattr(self.item_field, '__metaclass__', None)
         if issubclass(item_metaclass, models.SubfieldBase):
             setattr(cls, self.name, Creator(self))
+            
+        if isinstance(self.item_field, models.ForeignKey) and isinstance(self.item_field.rel.to, basestring):
+            """
+            If rel.to is a string because the actual class is not yet defined, look up the
+            actual class later.  Refer to django.models.fields.related.RelatedField.contribute_to_class.
+            """
+            def _resolve_lookup(_, resolved_model, __):
+                self.item_field.rel.to = resolved_model
+                self.item_field.do_related_class(self, cls)
+            add_lazy_relation(cls, self, self.item_field.rel.to, _resolve_lookup)
 
     def _map(self, function, iterable, *args, **kwargs):
         """
@@ -121,8 +131,13 @@ class AbstractIterableField(models.Field):
         """
         if value is None:
             return None
-        return self._map(self.item_field.get_db_prep_save, value,
+        
+        try:
+            return self._map(self.item_field.get_db_prep_save, value,
                          connection=connection)
+        except AttributeError, e:
+            import eat
+            eat.gaebp(True)
 
     def get_db_prep_lookup(self, lookup_type, value, connection,
                            prepared=False):
@@ -257,16 +272,13 @@ class EmbeddedModelField(models.Field):
         rely on the collection field telling us its model (by setting
         our "model" attribute in its contribute_to_class method).
         """
+        self._model = model
         if model is not None and isinstance(self.embedded_model, basestring):
 
             def _resolve_lookup(self_, resolved_model, model):
                 self.embedded_model = resolved_model
 
-            from django.db.models.fields.related import add_lazy_relation
-            add_lazy_relation(model, self, self.embedded_model,
-                              _resolve_lookup)
-
-        self._model = model
+            add_lazy_relation(model, self, self.embedded_model, _resolve_lookup)
 
     model = property(lambda self: self._model, _set_model)
 


### PR DESCRIPTION
Before this change, the AbstractIterableField could only handle a related field where the relation was actually defined as a class.

It wouldn't handle ForeignKeys defined with a string with the name of the related class.
If we get a ForeignKey field where the related class is not defined, register a signal handler to handle class registration, and complete the ForeignKey related field when the related class is found.
This fix only handles ForeignKeys, right now, but it ough to be improved to handle other RelatedFields as well.
