### PR TITLE
Allow for querying empty lists

### DIFF
--- a/djangotoolbox/db/base.py
+++ b/djangotoolbox/db/base.py
@@ -403,6 +403,9 @@ class NonrelDatabaseOperations(BaseDatabaseOperations):
 
         # Do convert filter parameters.
         if lookup:
+            # Special case where we are looking for an empty list
+            if lookup == 'exact' and db_type == 'list' and value == u'[]':
+                return []
             value = self._value_for_db(value, subfield,
                                        subkind, db_subtype, lookup)
 


### PR DESCRIPTION
I come across the case where I would want to see if a list is empty. 

This allows for that to work on mongodb. In appengine, this gets shortcut by the check at https://github.com/django-nonrel/djangoappengine/blob/develop/db/compiler.py#L186 so there is no change on appengine.
