### PR TITLE
Fix get_selected_fields for Django 1.8

### DIFF
--- a/djangotoolbox/db/basecompiler.py
+++ b/djangotoolbox/db/basecompiler.py
@@ -28,13 +28,21 @@ if django.VERSION >= (1, 5):
 else:
     from django.db.models.sql.constants import LOOKUP_SEP
 
-if django.VERSION >= (1, 6):
+if django.VERSION >= (1, 8):
+    def get_selected_fields(query):
+        if query.select:
+            return [info.target for info in query.select]
+        else:
+            return query.model._meta.fields
+
+elif django.VERSION >= (1, 6):
     def get_selected_fields(query):
         if query.select:
             return [info.field for info in (query.select +
                         query.related_select_cols)]
         else:
             return query.model._meta.fields
+
 else:
     def get_selected_fields(query):
         if query.select_fields:


### PR DESCRIPTION
* The way selected fields are aggregated has been refactored so that only query.select contains the selected fields and the field object is in the target attribute instead of the info attribute. I made these changes and cased it specifically for Django 1.8 leaving the legacy implementations intact.